### PR TITLE
I2cdev fix cs_mipi

### DIFF
--- a/i2c_cmd/bin/cs_mipi_i2c.sh
+++ b/i2c_cmd/bin/cs_mipi_i2c.sh
@@ -58,7 +58,7 @@
 
 COMMENT_SAMPLE
 
-I2C_DEV=10;
+I2C_DEV=0;
 I2C_ADDR=0x3b;
 
 print_usage()


### PR DESCRIPTION
Fixing the i2cdev in cs_mipi file to match the i2c of the camera.